### PR TITLE
Minor fix to type signatures, small change to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cabal.project.local~
 .ghc.environment.*
 *~
 *.cabal
+*.lock

--- a/src/Data/SafeJSON.hs
+++ b/src/Data/SafeJSON.hs
@@ -58,8 +58,8 @@ module Data.SafeJSON
     --
     -- | The following functions are helpful when defining 'safeFrom'.
     --   They are basically 'contain' composed with the corresponding
-    --   'Data.Aeson' function, so they can be used in the same fashion
-    --   as said 'Data.Aeson' function.
+    --   "Data.Aeson" function, so they can be used in the same fashion
+    --   as said "Data.Aeson" function.
     , containWithObject
     , containWithArray
     , containWithText
@@ -67,7 +67,7 @@ module Data.SafeJSON
     , containWithBool
     -- *** Accessors
     --
-    -- | These accessors can be used like their 'Data.Aeson' counterparts.
+    -- | These accessors can be used like their "Data.Aeson" counterparts.
     --   The only difference is that the expected value is parsed using
     --   'safeFromJSON' instead of 'Data.Aeson.parseJSON'.
     , (.:$)
@@ -76,7 +76,7 @@ module Data.SafeJSON
     -- *** Constructor for 'safeTo'
     --
     -- | This constructor of key-value pairs can be used exactly like
-    --   its 'Data.Aeson' counterpart ('Data.Aeson..='), but converts the
+    --   its "Data.Aeson" counterpart ('Data.Aeson..='), but converts the
     --   given value with 'safeToJSON' instead of 'Data.Aeson.toJSON'
     , (.=$)
     -- ** Version

--- a/src/Data/SafeJSON/Internal.hs
+++ b/src/Data/SafeJSON/Internal.hs
@@ -262,7 +262,7 @@ setVersion' (Version mVersion) val =
 --   (cf. 'removeVersion') In some rare cases, you might want to interpret
 --   a versionless 'Value' as a certain type/version. 'setVersion' allows
 --   you to (unsafely) insert a version field.
-
+--
 --   __If possible, it is advised to use a 'FromJSON' instance instead.__
 --   (One that doesn't also use `safeFromJSON` in its methods!)
 --

--- a/src/Data/SafeJSON/Test.hs
+++ b/src/Data/SafeJSON/Test.hs
@@ -162,10 +162,9 @@ migrateReverseRoundTrip newType = "Unexpected result of decoding encoded newer t
 -- | Constraints for migrating from a previous version
 type TestMigrate a b =
     ( Eq a
-    , Show (MigrateFrom a)
-    , Arbitrary (MigrateFrom a)
+    , Show b
+    , Arbitrary b
     , SafeJSON a
-    , SafeJSON (MigrateFrom a)
     , Migrate a
     , MigrateFrom a ~ b
     )
@@ -195,8 +194,8 @@ migrateRoundTripProp s = testProperty s $ \a ->
 -- | Constraints for migrating from a future version
 type TestReverseMigrate a b =
     ( Eq a
-    , Show (MigrateFrom (Reverse a))
-    , Arbitrary (MigrateFrom (Reverse a))
+    , Show b
+    , Arbitrary b
     , SafeJSON a
     , Migrate (Reverse a)
     , MigrateFrom (Reverse a) ~ b


### PR DESCRIPTION
  * in type signatures that have `MigrateFrom a ~ b` (`TestMigrate` and `TestReverseMigrate`), replaced `MigrateFrom a` in other places with `b`, so it's a bit less verbose.
  * added `.lock` to gitignore
  * `@since 1.0.0` already in description; added `--` to empty line so docs compile properly
  * Changed 4 instances of `'Data.Aeson'` to `"Data.Aeson"`

