### PR TITLE
Allow text-2.0, accurate dep bounds

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -55,7 +55,7 @@ dependencies:
 - tasty                 >= 0.11.3     && < 1.5
 - tasty-hunit           >= 0.9.2      && < 0.11
 - tasty-quickcheck      >= 0.8.4      && < 0.11
-- text                  >= 1.2.3      && < 1.3
+- text                  >= 1.2.3      && < 2.1
 - time                  >= 1.6.0.1    && < 1.10
 - unordered-containers  >= 0.2.9      && < 0.3
 - uuid-types            >= 1.0.3      && < 1.1

--- a/safe-json.cabal
+++ b/safe-json.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a6ae844e40805e77ae73d018b0c1f362112616ba5f8773f87d87074f6600a92d
+-- hash: ae526517deccd786d4dc9ad772e94df13901556f5f2d4904b663591cbf9e4658
 
 name:           safe-json
 version:        1.1.2.0
@@ -74,7 +74,7 @@ library
     , tasty >=0.11.3 && <1.5
     , tasty-hunit >=0.9.2 && <0.11
     , tasty-quickcheck >=0.8.4 && <0.11
-    , text >=1.2.3 && <1.3
+    , text >=1.2.3 && <2.1
     , time >=1.6.0.1 && <1.10
     , unordered-containers >=0.2.9 && <0.3
     , uuid-types >=1.0.3 && <1.1
@@ -107,7 +107,7 @@ test-suite safe-json-test
     , bytestring >=0.10.8.1 && <0.11
     , containers >=0.5.7.1 && <0.7
     , dlist >=0.8.0.3 && <2
-    , generic-arbitrary >=0.1.0 && <0.4
+    , generic-arbitrary >=0.1.0 && <0.3
     , hashable >=1.2.6.1 && <1.5
     , quickcheck-instances >=0.3.16 && <0.4
     , safe-json
@@ -116,7 +116,7 @@ test-suite safe-json-test
     , tasty-hunit
     , tasty-quickcheck
     , temporary >=1.2.1.1 && <1.4
-    , text >=1.2.3 && <1.3
+    , text >=1.2.3 && <2.1
     , time >=1.6.0.1 && <1.10
     , unordered-containers >=0.2.9 && <0.3
     , uuid >=1.3.13 && <1.4

--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -46,6 +46,7 @@ instance (Arbitrary a, VP.Prim a) => Arbitrary (VP.Vector a) where
   arbitrary = VP.fromList <$> arbitrary
   shrink = fmap VP.fromList . shrink . VP.toList
 
+#if !MIN_VERSION_aeson(2,0,3)
 instance Arbitrary Value where
   arbitrary = oneof
     [ resize 5 $ Object <$> arbitrary
@@ -56,6 +57,7 @@ instance Arbitrary Value where
     , pure Null
     ]
   shrink = genericShrink
+#endif
 
 #if !MIN_VERSION_aeson(1,5,2)
 -- | This is here just to test 'Set' in 'parseCollection'
@@ -79,7 +81,7 @@ instance Ord Value where
   _        `compare` _        = GT
 #endif
 
-#if MIN_VERSION_aeson(2,0,0)
+#if !MIN_VERSION_aeson(2,0,3)
 instance Arbitrary v => Arbitrary (KM.KeyMap v) where
     arbitrary = KM.fromList <$> arbitrary
 

--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -81,7 +81,7 @@ instance Ord Value where
   _        `compare` _        = GT
 #endif
 
-#if !MIN_VERSION_aeson(2,0,3)
+#if MIN_VERSION_aeson(2,0,0) && !MIN_VERSION_aeson(2,0,3)
 instance Arbitrary v => Arbitrary (KM.KeyMap v) where
     arbitrary = KM.fromList <$> arbitrary
 


### PR DESCRIPTION
Tested using this configuration as an example of Aeson between 2 and 2.0.2 (also demonstrates text>=2):

    cabal test --constraint 'text>=2' --constraint='generic-arbitrary<0.3' -w ghc-9.0.2 --enable-tests --constraint='aeson==2.0.2.0'

Using this for Aeson 2.0.3+:

    cabal test --constraint='generic-arbitrary<0.3' -w ghc-9.0.2 --enable-tests --constraint='aeson==2.0.3.0'

The cabal file is regenerated and this lowers the generic-arbitrary bound which was raised to allow the 0.3 series, even though it isn't even released.
