### PR TITLE
Time dependency update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           - "--resolver lts-14" # GHC 8.6.5
           - "--resolver lts-16" # GHC 8.8.4
           - "--resolver lts-18" # GHC 8.10.7
-          - "--resolver nightly" # GHC 9.0.2
+          - "--resolver lts-19" # GHC 9.0.2
+          - "--resolver nightly" # GHC 9.2.2
 
     steps:
     - uses: actions/checkout@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for safe-json
 
+## 1.1.3.1
+
+* Compatibility with GHC 9.2.*, and `time < 0.13`
+
 ## 1.1.3.0
 
 * Compatibility with `aeson < 2.1` and `text < 2.1` [#33](https://github.com/Vlix/safe-json/pull/33) Thanks to [@ysangkok](https://github.com/ysangkok)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                safe-json
-version:             1.1.3.0
+version:             1.1.3.1
 github:              "Vlix/safe-json"
 license:             MIT
 author:              "Felix Paulusma"
@@ -8,7 +8,7 @@ copyright:           "2019 Felix Paulusma"
 # Metadata used when publishing your package
 synopsis:            Automatic JSON format versioning
 category:            "JSON"
-tested-with:         GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2
+tested-with:         GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.2
 
 extra-source-files:
 - README

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,7 @@ dependencies:
 - tasty-hunit           >= 0.9.2      && < 0.11
 - tasty-quickcheck      >= 0.8.4      && < 0.11
 - text                  >= 1.2.3      && < 2.1
-- time                  >= 1.6.0.1    && < 1.10
+- time                  >= 1.6.0.1    && < 1.13
 - unordered-containers  >= 0.2.9      && < 0.3
 - uuid-types            >= 1.0.3      && < 1.1
 - vector                >= 0.12.0.1   && < 0.13

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,6 @@ description: >
 
 
 dependencies:
-- aeson                 >= 1.4.1      && < 2.1
 - base                  >= 4.9        && < 5
 - bytestring            >= 0.10.8.1   && < 0.12
 - containers            >= 0.5.7.1    && < 0.7
@@ -69,6 +68,9 @@ library:
     - Data.SafeJSON.Test
   default-extensions:
     - OverloadedStrings
+  dependencies:
+    - aeson             >= 1.4.1      && < 2.1
+
 
 tests:
   safe-json-test:
@@ -78,8 +80,16 @@ tests:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
+    when:
+      - condition: impl(ghc >= 9.2.0)
+        then:
+          dependencies:
+            - aeson                 >= 2.0.3.0  && < 2.1
+        else:
+          dependencies:
+            - aeson                 >= 1.4.1    && < 2.1
+            - generic-arbitrary     >= 0.1.0    && < 0.3
     dependencies:
-      - generic-arbitrary     >= 0.1.0    && < 0.3
       - safe-json
       - quickcheck-instances  >= 0.3.16   && < 0.4
       - tasty

--- a/safe-json.cabal
+++ b/safe-json.cabal
@@ -73,7 +73,7 @@ library
     , tasty-hunit >=0.9.2 && <0.11
     , tasty-quickcheck >=0.8.4 && <0.11
     , text >=1.2.3 && <2.1
-    , time >=1.6.0.1 && <1.10
+    , time >=1.6.0.1 && <1.13
     , unordered-containers >=0.2.9 && <0.3
     , uuid-types >=1.0.3 && <1.1
     , vector >=0.12.0.1 && <0.13
@@ -115,7 +115,7 @@ test-suite safe-json-test
     , tasty-quickcheck
     , temporary >=1.2.1.1 && <1.4
     , text >=1.2.3 && <2.1
-    , time >=1.6.0.1 && <1.10
+    , time >=1.6.0.1 && <1.13
     , unordered-containers >=0.2.9 && <0.3
     , uuid >=1.3.13 && <1.4
     , uuid-types >=1.0.3 && <1.1

--- a/safe-json.cabal
+++ b/safe-json.cabal
@@ -100,12 +100,10 @@ test-suite safe-json-test
       OverloadedStrings
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.4.1 && <2.1
-    , base >=4.9 && <5
+      base >=4.9 && <5
     , bytestring >=0.10.8.1 && <0.12
     , containers >=0.5.7.1 && <0.7
     , dlist >=0.8.0.3 && <2
-    , generic-arbitrary >=0.1.0 && <0.3
     , hashable >=1.2.6.1 && <1.5
     , quickcheck-instances >=0.3.16 && <0.4
     , safe-json
@@ -120,4 +118,11 @@ test-suite safe-json-test
     , uuid >=1.3.13 && <1.4
     , uuid-types >=1.0.3 && <1.1
     , vector >=0.12.0.1 && <0.13
+  if impl(ghc >= 9.2.0)
+    build-depends:
+        aeson >=2.0.3.0 && <2.1
+  else
+    build-depends:
+        aeson >=1.4.1 && <2.1
+      , generic-arbitrary >=0.1.0 && <0.3
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-18.20
+resolver: lts-19.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/Instances.hs
+++ b/test/Instances.hs
@@ -19,13 +19,11 @@ import Data.Time (NominalDiffTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import qualified Data.Vector.Primitive as VP
 
-#if !MIN_VERSION_base(4,13,0)
 import Test.Tasty.QuickCheck (Arbitrary(..))
-#endif
 #if !MIN_VERSION_aeson(2,0,3)
 import Test.Tasty.QuickCheck (oneof, resize)
+import Test.QuickCheck.Arbitrary.Generic (genericShrink)
 #endif
-import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Instances()
 
 instance Arbitrary DotNetTime where
@@ -46,6 +44,14 @@ instance Arbitrary a => Arbitrary (DList a) where
 instance (Arbitrary a, VP.Prim a) => Arbitrary (VP.Vector a) where
   arbitrary = VP.fromList <$> arbitrary
   shrink = fmap VP.fromList . shrink . VP.toList
+
+#if MIN_VERSION_aeson(2,0,0) && !MIN_VERSION_aeson(2,0,3)
+instance Arbitrary v => Arbitrary (KM.KeyMap v) where
+    arbitrary = KM.fromList <$> arbitrary
+
+instance Arbitrary K.Key where
+    arbitrary = K.fromText <$> arbitrary
+#endif
 
 #if !MIN_VERSION_aeson(2,0,3)
 instance Arbitrary Value where
@@ -80,12 +86,4 @@ instance Ord Value where
   String{} `compare` _        = LT
   Array{}  `compare` Object{} = LT
   _        `compare` _        = GT
-#endif
-
-#if MIN_VERSION_aeson(2,0,0) && !MIN_VERSION_aeson(2,0,3)
-instance Arbitrary v => Arbitrary (KM.KeyMap v) where
-    arbitrary = KM.fromList <$> arbitrary
-
-instance Arbitrary K.Key where
-    arbitrary = K.fromText <$> arbitrary
 #endif

--- a/test/VersionNum.hs
+++ b/test/VersionNum.hs
@@ -9,7 +9,7 @@ import Test.Tasty.QuickCheck as Tasty
 
 numTest :: (Num a, Eq a, Arbitrary a, Show a) => Proxy a -> TestTree
 numTest p = testGroup "Version's Num instance" $
-    ($p) <$> [plusTest, minusTest, multTest, negateTest, absSignumTest]
+    ($ p) <$> [plusTest, minusTest, multTest, negateTest, absSignumTest]
 
 plusTest :: forall a. (Num a, Eq a, Arbitrary a, Show a) => Proxy a -> TestTree
 plusTest _ = testGroup "Plus laws"


### PR DESCRIPTION
Loosened `time` dependency constraint and prepped to build with GHC 9.2.2